### PR TITLE
QC filtering bits.

### DIFF
--- a/.nf-core.yml
+++ b/.nf-core.yml
@@ -1,4 +1,5 @@
 repository_type: pipeline
+org_path: ebi-metagenomics
 template:
   prefix: ebi-metagenomics
   skip:

--- a/nextflow.config
+++ b/nextflow.config
@@ -46,6 +46,10 @@ params {
     library_layout                   = null
     library_strategy                 = null
 
+    // Reads QC filtering options
+    filter_ratio_threshold           = 0.9
+    low_reads_count_threshold        = 1000
+
     // Reference genome
     reference_genome                 = null
 

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -155,6 +155,25 @@
                 }
             }
         },
+        "reads_qc": {
+            "title": "Reads QC options",
+            "type": "object",
+            "fa_icon": "fab fa-acquisitions-incorporated",
+            "description": "Set the thresholds for the reads QC/filtering steps. Reads that fail QC won't be assembled.",
+            "help_text": "Use these options to define the quality control thresholds for your reads. You can specify the maximum allowed filtering ratio and the minimum acceptable read count. If the filtering ratio exceeds the set limit or the read count falls below the threshold, the reads will be flagged and excluded from further assembly. The information about those runs that failed are aggregated in the qc_failed_runs.csv file.",
+            "properties": {
+                "filter_ratio_threshold": {
+                    "type": "number",
+                    "description": "The maximum allowed ratio of reads after filtering compared to before filtering. If exceeded, it flags excessive filtering. The default value is 0.9, meaning that if more than 90% of the reads are filtered out, the threshold is considered exceeded and the run is not assembled.",
+                    "default": 0.9
+                },
+                "low_reads_count_threshold": {
+                    "type": "number",
+                    "description": "The minimum number of reads required after filtering. If below, it flags a low read count and the run is not assembled..",
+                    "default": 1000
+                }
+            }
+        },
         "max_job_request_options": {
             "title": "Max job request options",
             "type": "object",
@@ -277,6 +296,9 @@
     "allOf": [
         {
             "$ref": "#/defs/input_output_options"
+        },
+        {
+            "$ref": "#/defs/reads_qc"
         },
         {
             "$ref": "#/defs/max_job_request_options"

--- a/subworkflows/local/assembly_coverage.nf
+++ b/subworkflows/local/assembly_coverage.nf
@@ -6,14 +6,14 @@ include { METABAT2_JGISUMMARIZEBAMCONTIGDEPTHS } from '../../modules/nf-core/met
 workflow ASSEMBLY_COVERAGE {
 
     take:
-    reads_assembly   // [ val(meta), path(reads), path(assembly_fasta) ]
+    assembly_reads   // [ val(meta), path(assembly_fasta), path(reads) ]
 
     main:
 
     ch_versions = Channel.empty()
 
-    reads = reads_assembly.map { meta, reads, _ -> [meta, reads]}
-    assembly = reads_assembly.map { meta, _, assembly -> [meta, assembly]}
+    reads = assembly_reads.map { meta, _, reads -> [meta, reads] }
+    assembly = assembly_reads.map { meta, assembly, _ -> [meta, assembly] }
 
     BWAMEM2_INDEX(
         assembly

--- a/subworkflows/local/reads_qc.nf
+++ b/subworkflows/local/reads_qc.nf
@@ -61,6 +61,7 @@ workflow READS_QC {
     }
 
     emit:
-    qc_reads = decontaminated_reads
-    versions = ch_versions
+    qc_reads   = decontaminated_reads
+    fastp_json = FASTP.out.json
+    versions   = ch_versions
 }

--- a/workflows/miassembler.nf
+++ b/workflows/miassembler.nf
@@ -1,3 +1,6 @@
+// Groovy //
+import groovy.json.JsonSlurper
+
 /*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     PRINT PARAMS SUMMARY
@@ -186,10 +189,31 @@ workflow MIASSEMBLER {
         READS_QC.out.qc_reads
     )
 
-    READS_QC.out.qc_reads.branch { meta, reads ->
+    /******************************************/
+    /*  Reads that fail the following rules:  */
+    /*  - Reads discarded by fastp > 80%      */
+    /*  - Less than 1k reads                  */
+    /******************************************/
+    extended_qc = READS_QC.out.fastp_json.map { meta, json -> {
+            json_txt = new JsonSlurper().parseText(json.text)
+            bf_total_reads = json_txt?.summary?.before_filtering?.total_reads ?: 0;
+            af_total_reads = json_txt?.summary?.after_filtering?.total_reads ?: 0;
+            reads_qc_meta = [
+                "low_reads_count": af_total_reads <= params.low_reads_count_threshold,
+                "filter_ratio_threshold_exceeded": af_total_reads == 0 || ((af_total_reads / bf_total_reads) <= params.filter_ratio_threshold )
+            ]
+            return [meta, reads_qc_meta]
+        }
+    }
+
+    extended_reads_qc = READS_QC.out.qc_reads.join( extended_qc )
+
+    extended_reads_qc.branch { meta, reads, reads_qc_meta ->
+        // Filter out failed reads //
+        qc_failed: reads_qc_meta.low_reads_count || reads_qc_meta.filter_ratio_threshold_exceeded
         megahit: meta.assembler == "megahit"
         xspades: ["metaspades", "spades"].contains(meta.assembler)
-    }.set { qc_reads }
+    }.set { qc_filtered_reads }
 
     ch_versions = ch_versions.mix(READS_QC.out.versions)
 
@@ -197,7 +221,7 @@ workflow MIASSEMBLER {
     /*     Assembly     */
     /********************/
     SPADES(
-        qc_reads.xspades.map { meta, reads -> [meta, reads, [], []] },
+        qc_filtered_reads.xspades.map { meta, reads, _ -> [meta, reads, [], []] },
         [], // yml input parameters, which we don't use
         []  // hmm, not used
     )
@@ -205,7 +229,7 @@ workflow MIASSEMBLER {
     ch_versions = ch_versions.mix(SPADES.out.versions)
 
     MEGAHIT(
-        qc_reads.megahit
+        qc_filtered_reads.megahit.map { meta, reads, _ -> [meta, reads] }
     )
 
     assembly = SPADES.out.contigs.mix( MEGAHIT.out.contigs )
@@ -222,7 +246,7 @@ workflow MIASSEMBLER {
 
     // Coverage //
     ASSEMBLY_COVERAGE(
-        READS_QC.out.qc_reads.join( ASSEMBLY_QC.out.filtered_contigs )
+        ASSEMBLY_QC.out.filtered_contigs.join( READS_QC.out.qc_reads, remainder: false )
     )
 
     ch_versions = ch_versions.mix(ASSEMBLY_COVERAGE.out.versions)
@@ -325,11 +349,31 @@ workflow MIASSEMBLER {
         ch_multiqc_logo
     )
 
-    ch_multiqc_run_tools_files.map { it -> {
-        def meta = it[0]
-        meta["id"]
-    }}.collectFile(name: "end_samplesheet.csv", storeDir: "${params.outdir}", newLine: true)
+    /*****************************/
+    /* End of execution reports */
+    /****************************/
 
+    // Asssembled runs //
+    ASSEMBLY_COVERAGE.out.samtools_idxstats.map {
+        meta, _ -> {
+            return "${meta.id}"
+        }
+     }.collectFile(name: "assembled_runs.csv", storeDir: "${params.outdir}", newLine: true, cache: false)
+
+    // Reads QC failed //
+    qc_failed_entries = qc_filtered_reads.qc_failed.map {
+        meta, _, extended_meta -> {
+            if ( extended_meta.low_reads_count ) {
+                return "${meta.id},low_reads_count"
+            }
+            if ( extended_meta.filter_ratio_threshold_exceeded ) {
+                return "${meta.id},filter_ratio_threshold_exceeded"
+            }
+            error "Unexpected. meta: ${meta}, extended_meta: ${extended_meta}"
+        }
+    }
+
+    qc_failed_entries.collectFile(name: "qc_failed_runs.csv", storeDir: "${params.outdir}", newLine: true, cache: false)
 }
 
 /*


### PR DESCRIPTION
QC failed and assembed runs .csv "end of run" reports.

Using the fastq json file and some groovy, I've added an exclusion and reporting mechnism.

I've added two new QC options for miassembler:
  --filter_ratio_threshold:
    - The maximum allowed ratio of reads after filtering. If more than 90% of the reads are filtered out, the threshold is considered exceeded, and the run is not assembled. [default: 0.9]

  --low_reads_count_threshold:
    - The minimum number of reads required after filtering. If the read count falls below this threshold, the run is not assembled. [default: 1000]

If either threshold is exceeded the run is skipped, and the accessions are recorded in a CSV file (e.g., `SRR6180434,filter_ratio_threshold_exceeded`).

[Warning]
The unit tests need to be adjusted, and these changes should be tested thoroughly. I have only tested this locally.