### PR TITLE
Bugfix/assembler memory

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -109,6 +109,8 @@ process {
         // TODO: tweak this based on input ( using the biome maybe? )
         time   = { check_max( 168.h                    * task.attempt, 'time') }
         ext.args = params.spades_only_assembler ? "--only-assembler" : ""
+        errorStrategy = 'retry'
+        maxRetries    = params.max_spades_retries
 
         publishDir = [
             [
@@ -145,6 +147,8 @@ process {
         }
         cpus   = { check_max( 12    * task.attempt, 'cpus'    ) }
         time   = { check_max( 16.h  * task.attempt, 'time'    ) }
+        errorStrategy = 'retry'
+        maxRetries    = params.max_megahit_retries
 
         publishDir = [
             [

--- a/nextflow.config
+++ b/nextflow.config
@@ -89,6 +89,8 @@ params {
     max_memory                       = '1.TB'
     max_cpus                         = 32
     max_time                         = '168.h' // 7 days
+    max_spades_retries               = 5
+    max_megahit_retries              = 5
 
     // Assembler versions
     spades_version                   = "3.15.5"

--- a/nextflow.config
+++ b/nextflow.config
@@ -89,8 +89,8 @@ params {
     max_memory                       = '1.TB'
     max_cpus                         = 32
     max_time                         = '168.h' // 7 days
-    max_spades_retries               = 5
-    max_megahit_retries              = 5
+    max_spades_retries               = 3
+    max_megahit_retries              = 3
 
     // Assembler versions
     spades_version                   = "3.15.5"

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -125,7 +125,7 @@
                     "description": "Minimum contig length filter for metaT."
                 },
                 "assembly_memory": {
-                    "type": "integer",
+                    "type": "number",
                     "default": 100,
                     "description": "Default memory allocated for the assembly process."
                 },
@@ -208,6 +208,22 @@
                     "pattern": "^(\\d+\\.?\\s*(s|m|h|d|day)\\s*)+$",
                     "hidden": true,
                     "help_text": "Use to set an upper-limit for the time requirement for each process. Should be a string in the format integer-unit e.g. `--max_time '2.h'`"
+                },
+                "max_spades_retries": {
+                    "type": "integer",
+                    "description": "Maximum number of task attempt retries for (meta)spades assembly steps only.",
+                    "default": 5,
+                    "fa_icon": "fas fa-repeat",
+                    "hidden": true,
+                    "help_text": "Each retry will increase the memory by 50%. Use to limit how many times this increase-and-retry happens."
+                },
+                "max_megahit_retries": {
+                    "type": "integer",
+                    "description": "Maximum number of task attempt retries for megahit assembly steps only.",
+                    "default": 5,
+                    "fa_icon": "fas fa-repeat",
+                    "hidden": true,
+                    "help_text": "Each retry will increase the memory by 50%. Use to limit how many times this increase-and-retry happens."
                 }
             }
         },

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -212,7 +212,7 @@
                 "max_spades_retries": {
                     "type": "integer",
                     "description": "Maximum number of task attempt retries for (meta)spades assembly steps only.",
-                    "default": 5,
+                    "default": 3,
                     "fa_icon": "fas fa-repeat",
                     "hidden": true,
                     "help_text": "Each retry will increase the memory by 50%. Use to limit how many times this increase-and-retry happens."
@@ -220,7 +220,7 @@
                 "max_megahit_retries": {
                     "type": "integer",
                     "description": "Maximum number of task attempt retries for megahit assembly steps only.",
-                    "default": 5,
+                    "default": 3,
                     "fa_icon": "fas fa-repeat",
                     "hidden": true,
                     "help_text": "Each retry will increase the memory by 50%. Use to limit how many times this increase-and-retry happens."

--- a/tests/main.nf.test
+++ b/tests/main.nf.test
@@ -174,4 +174,33 @@ nextflow_pipeline {
         }
 
     }
+
+    test("Samplesheet spades - retries") {
+
+        tag "samplesheet"
+        tag "retries"
+
+        when {
+            params {
+                outdir = "tests/results"
+                assembler = "spades"
+                bwamem2_reference_genomes_folder = "${projectDir}/tests/human_phix/bwa2mem"
+                blast_reference_genomes_folder   = "${projectDir}/tests/human_phix/blast"
+                samplesheet                      = "${projectDir}/tests/samplesheet/test_mem.csv"
+                assembly_memory                  = 0.5
+                  // will will be [0.5GB, 0.75GB, 1.13GB, ...] which rounds down to [0, 0, 1, ...] so should definitely fail twice before succeeding. after a few trys.
+                max_spades_retries               = 5
+            }
+        }
+
+        then {
+            with(workflow) {
+                assert success
+                assert trace.succeeded().count{ task -> task.name.contains("SPADES") } == 1
+                assert workflow.errorReport.contains("Execution is retried (1)")
+                assert workflow.errorReport.contains("Execution is retried (2)")
+            }
+        }
+
+    }
 }

--- a/tests/main.nf.test
+++ b/tests/main.nf.test
@@ -195,10 +195,13 @@ nextflow_pipeline {
 
         then {
             with(workflow) {
+                // eventual success:
                 assert success
                 assert trace.succeeded().count{ task -> task.name.contains("SPADES") } == 1
-                assert workflow.errorReport.contains("Execution is retried (1)")
-                assert workflow.errorReport.contains("Execution is retried (2)")
+
+                // but failed and therefore retried multiple times first:
+                assert trace.failed().count{ task -> task.name.contains("SPADES") } >= 2
+                assert workflow.getStdout().join("").contains("Execution is retried")
             }
         }
 

--- a/tests/main.nf.test
+++ b/tests/main.nf.test
@@ -201,7 +201,6 @@ nextflow_pipeline {
 
                 // but failed and therefore retried multiple times first:
                 assert trace.failed().count{ task -> task.name.contains("SPADES") } >= 2
-                assert workflow.getStdout().join("").contains("Execution is retried")
             }
         }
 

--- a/tests/samplesheet/test_mem.csv
+++ b/tests/samplesheet/test_mem.csv
@@ -1,0 +1,2 @@
+study_accession,reads_accession,fastq_1,fastq_2,library_layout,library_strategy,assembler,assembly_memory
+SRP115494,SRR5949318,https://github.com/EBI-Metagenomics/miassembler/raw/main/tests/test_reads/SRR5949318_1.fastq.gz,https://github.com/EBI-Metagenomics/miassembler/raw/main/tests/test_reads/SRR5949318_2.fastq.gz,paired,metagenomic,,

--- a/workflows/miassembler.nf
+++ b/workflows/miassembler.nf
@@ -135,7 +135,7 @@ workflow MIASSEMBLER {
                 [ meta + [
                     //  -- The metadata will be overriden by the parameters -- //
                     "assembler": params.assembler,
-                    "assembly_memory": params.assembler_memory,
+                    "assembly_memory": params.assembly_memory,
                     "library_strategy": params.library_strategy ?: library_strategy,
                     "library_layout": params.library_layout ?: library_layout,
                     "single_end": params.single_end ?: library_layout == "single"


### PR DESCRIPTION
## PR checklist

This PR improves the retry-with-more-memory logic, by setting `maxRetries` directive to a parameter (default 5) specifically for the spades/megahit assembly modules. The more-memory-with-each-attempt was already present, this just allows those retries to happen.

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/ebi-metagenomics/miassembler/tree/master/.github/CONTRIBUTING.md)
- [ ] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
