### PR TITLE
Filter operator fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ SRR6180434,short_reads_filter_ratio_threshold_exceeded
 
 | Exclusion Message                 | Description                                                                                                                                                                                                                                                                            |
 | --------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `short_reads_filter_ratio_threshold_exceeded` | The maximum fraction of reads that are allowed to be filtered out. If exceeded, it flags excessive filtering. The default value is 0.9, meaning that if more than 90% of the reads are filtered out, the threshold is considered exceeded, and the run is not assembled. |
+| `short_reads_filter_ratio_threshold_exceeded` | The maximum fraction of reads that are allowed to be filtered out. If exceeded, it flags excessive filtering. The default value is 0.1, meaning that if less than 10% of the reads are retained after filtering, the threshold is considered exceeded, and the run is not assembled. |
 | `short_reads_low_reads_count_threshold`       | The minimum number of reads required after filtering. If below, it flags a low read count, and the run is not assembled.                                                                                                                                                               |
 
 #### Assembled Runs

--- a/nextflow.config
+++ b/nextflow.config
@@ -32,7 +32,7 @@ params {
     // QC FILTERING
 
     // Short reads QC filtering options
-    short_reads_filter_ratio_threshold    = 0.9
+    short_reads_filter_ratio_threshold    = 0.1
     short_reads_low_reads_count_threshold = 1000
 
     // Long reads options

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -194,8 +194,8 @@
             "properties": {
                 "short_reads_filter_ratio_threshold": {
                     "type": "number",
-                    "description": "The maximum fraction of reads that are allowed to be filtered out. If exceeded, it flags excessive filtering. The default value is 0.9, meaning that if more than 90% of the reads are filtered out, the threshold is considered exceeded, and the run is not assembled.",
-                    "default": 0.9,
+                    "description": "The maximum fraction of reads that are allowed to be filtered out. If exceeded, it flags excessive filtering. The default value is 0.1, meaning that if less than 10% of the reads are retained after filtering, the threshold is considered exceeded, and the run is not assembled.",
+                    "default": 0.1,
                     "minimum": 0.0,
                     "maximum": 1.0
                 },

--- a/workflows/short_reads_assembler.nf
+++ b/workflows/short_reads_assembler.nf
@@ -94,7 +94,7 @@ workflow SHORT_READS_ASSEMBLER {
 
     /******************************************/
     /*  Reads that fail the following rules:  */
-    /*  - Reads discarded by fastp > 90% (default value) */
+    /*  - Reads kept by fastp < 10% (default value) */
     /*  - Less than 1k reads                  */
     /******************************************/
     extended_qc = SHORT_READS_QC.out.fastp_json.map { meta, json -> {


### PR DESCRIPTION
<!--
# ebi-metagenomics/miassembler pull request

Many thanks for contributing to ebi-metagenomics/miassembler!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/ebi-metagenomics/miassembler/tree/master/.github/CONTRIBUTING.md)
-->

Fix for the filter ratio threshold logic. Documentation stated that samples where less than 10% of reads were kept after filtering were flagged and not assembled. However the code was flagging samples that met this criteria:

`(af_total_reads / bf_total_reads) <= params.filter_ratio_threshold`

It was discarding samples where the proportion of passed reads was less than 90%. I've changed the filter threshold in the config to 10% to flag only the samples with less than 10% of the reads retained. I've also updated the description in the workflow and the README.

We haven't yet modified the tests affected by this change.

## PR checklist

- [X] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/ebi-metagenomics/miassembler/tree/master/.github/CONTRIBUTING.md)
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [X] `README.md` is updated (including new tool citations and authors/contributors).
