### PR TITLE
Feature/add megahit graph

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -8,13 +8,17 @@
                     "bwamem2/mem": {
                         "branch": "main",
                         "git_sha": "75707538d91ddd27fb6007b4ac3710cb05154780",
-                        "installed_by": ["modules"],
+                        "installed_by": [
+                            "modules"
+                        ],
                         "patch": "modules/ebi-metagenomics/bwamem2/mem/bwamem2-mem.diff"
                     },
                     "bwamem2decontnobams": {
                         "branch": "main",
                         "git_sha": "32049180387cf2406254acf57882fc55915cb52e",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     }
                 }
             }
@@ -25,111 +29,151 @@
                     "blast/blastn": {
                         "branch": "master",
                         "git_sha": "666652151335353eef2fcd58880bcef5bc2928e1",
-                        "installed_by": ["modules"],
+                        "installed_by": [
+                            "modules"
+                        ],
                         "patch": "modules/nf-core/blast/blastn/blast-blastn.diff"
                     },
                     "bwamem2/index": {
                         "branch": "master",
                         "git_sha": "3f5420aa22e00bd030a2556dfdffc9e164ec0ec5",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "canu": {
                         "branch": "master",
                         "git_sha": "8fc1d24c710ebe1d5de0f2447ec9439fd3d9d66a",
-                        "installed_by": ["modules"],
+                        "installed_by": [
+                            "modules"
+                        ],
                         "patch": "modules/nf-core/canu/canu.diff"
                     },
                     "custom/dumpsoftwareversions": {
                         "branch": "master",
                         "git_sha": "82024cf6325d2ee194e7f056d841ecad2f6856e9",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "fastp": {
                         "branch": "master",
                         "git_sha": "1ceaa8ba4d0fd886dbca0e545815d905b7407de7",
-                        "installed_by": ["modules"],
+                        "installed_by": [
+                            "modules"
+                        ],
                         "patch": "modules/nf-core/fastp/fastp.diff"
                     },
                     "fastqc": {
                         "branch": "master",
                         "git_sha": "21f230b8cca43755bf73470e6fd0290832a98aef",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "flye": {
                         "branch": "master",
                         "git_sha": "8fc1d24c710ebe1d5de0f2447ec9439fd3d9d66a",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "medaka": {
                         "branch": "master",
                         "git_sha": "8fc1d24c710ebe1d5de0f2447ec9439fd3d9d66a",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "megahit": {
                         "branch": "master",
                         "git_sha": "7755db15e36b30da564cd67fffdfe18a255092aa",
-                        "installed_by": ["modules"],
+                        "installed_by": [
+                            "modules"
+                        ],
                         "patch": "modules/nf-core/megahit/megahit.diff"
                     },
                     "metabat2/jgisummarizebamcontigdepths": {
                         "branch": "master",
                         "git_sha": "3f5420aa22e00bd030a2556dfdffc9e164ec0ec5",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "minimap2/align": {
                         "branch": "master",
                         "git_sha": "a33ef9475558c6b8da08c5f522ddaca1ec810306",
-                        "installed_by": ["modules"],
+                        "installed_by": [
+                            "modules"
+                        ],
                         "patch": "modules/nf-core/minimap2/align/minimap2-align.diff"
                     },
                     "multiqc": {
                         "branch": "master",
                         "git_sha": "cf17ca47590cc578dfb47db1c2a44ef86f89976d",
-                        "installed_by": ["modules"],
+                        "installed_by": [
+                            "modules"
+                        ],
                         "patch": "modules/nf-core/multiqc/multiqc.diff"
                     },
                     "porechop/abi": {
                         "branch": "master",
                         "git_sha": "870f9af2eaf0000c94d74910d762cf153752af98",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "quast": {
                         "branch": "master",
                         "git_sha": "3f5420aa22e00bd030a2556dfdffc9e164ec0ec5",
-                        "installed_by": ["modules"],
+                        "installed_by": [
+                            "modules"
+                        ],
                         "patch": "modules/nf-core/quast/quast.diff"
                     },
                     "racon": {
                         "branch": "master",
                         "git_sha": "8fc1d24c710ebe1d5de0f2447ec9439fd3d9d66a",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "samtools/idxstats": {
                         "branch": "master",
                         "git_sha": "a64788f5ad388f1d2ac5bd5f1f3f8fc81476148c",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "samtools/index": {
                         "branch": "master",
                         "git_sha": "a64788f5ad388f1d2ac5bd5f1f3f8fc81476148c",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "seqkit/grep": {
                         "branch": "master",
                         "git_sha": "3f5420aa22e00bd030a2556dfdffc9e164ec0ec5",
-                        "installed_by": ["modules"],
+                        "installed_by": [
+                            "modules"
+                        ],
                         "patch": "modules/nf-core/seqkit/grep/seqkit-grep.diff"
                     },
                     "seqkit/seq": {
                         "branch": "master",
                         "git_sha": "687ad41c14008d3d55cf7c2ffacebe6a057211a4",
-                        "installed_by": ["modules"],
+                        "installed_by": [
+                            "modules"
+                        ],
                         "patch": "modules/nf-core/seqkit/seq/seqkit-seq.diff"
                     },
                     "spades": {
                         "branch": "master",
                         "git_sha": "3f5420aa22e00bd030a2556dfdffc9e164ec0ec5",
-                        "installed_by": ["modules"],
+                        "installed_by": [
+                            "modules"
+                        ],
                         "patch": "modules/nf-core/spades/spades.diff"
                     }
                 }

--- a/modules/nf-core/megahit/main.nf
+++ b/modules/nf-core/megahit/main.nf
@@ -1,22 +1,23 @@
 process MEGAHIT {
-    tag "${meta.id}"
+    tag "$meta.id"
     label 'process_high'
+
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/f2/f2cb827988dca7067ff8096c37cb20bc841c878013da52ad47a50865d54efe83/data' :
-        'community.wave.seqera.io/library/megahit_pigz:87a590163e594224' }"
+        'https://depot.galaxyproject.org/singularity/mulled-v2-0f92c152b180c7cd39d9b0e6822f8c89ccb59c99:8ec213d21e5d03f9db54898a2baeaf8ec729b447-0' :
+        'biocontainers/mulled-v2-0f92c152b180c7cd39d9b0e6822f8c89ccb59c99:8ec213d21e5d03f9db54898a2baeaf8ec729b447-0' }"
 
     input:
     tuple val(meta), path(reads)
 
     output:
-    tuple val(meta), path("*.contigs.fa.gz")                            , emit: contigs
-    tuple val(meta), path("intermediate_contigs/k*.contigs.fa.gz")      , emit: k_contigs
-    tuple val(meta), path("intermediate_contigs/k*.addi.fa.gz")         , emit: addi_contigs
-    tuple val(meta), path("intermediate_contigs/k*.local.fa.gz")        , emit: local_contigs
-    tuple val(meta), path("intermediate_contigs/k*.final.contigs.fa.gz"), emit: kfinal_contigs
-    tuple val(meta), path('*.log')                                      , emit: log
-    path "versions.yml"                                                 , emit: versions
+    tuple val(meta), path("megahit_out/*.contigs.fa.gz")                            , emit: contigs
+    tuple val(meta), path("megahit_out/*.fastg.gz")                                 , emit: graph
+    tuple val(meta), path("megahit_out/intermediate_contigs/k*.contigs.fa.gz")      , emit: k_contigs
+    tuple val(meta), path("megahit_out/intermediate_contigs/k*.addi.fa.gz")         , emit: addi_contigs
+    tuple val(meta), path("megahit_out/intermediate_contigs/k*.local.fa.gz")        , emit: local_contigs
+    tuple val(meta), path("megahit_out/intermediate_contigs/k*.final.contigs.fa.gz"), emit: kfinal_contigs
+    path "versions.yml"                                                             , emit: versions
 
     when:
     task.ext.when == null || task.ext.when
@@ -25,46 +26,64 @@ process MEGAHIT {
     def args = task.ext.args ?: ''
     def args2 = task.ext.args2 ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
-    def reads_command = meta.single_end ? "-r ${reads}" : "-1 ${reads[0]} -2 ${reads[1]}"
-    """
-    megahit \\
-        ${reads_command} \\
-        ${args} \\
-        -t ${task.cpus} \\
-        --out-prefix ${prefix}
+    if (meta.single_end) {
+        """
+        megahit \\
+            -r ${reads} \\
+            -t $task.cpus \\
+            $args \\
+            --out-prefix $prefix
 
-    pigz \\
-        --no-name \\
-        -p ${task.cpus} \\
-        ${args2} \\
-        megahit_out/*.fa \\
-        megahit_out/intermediate_contigs/*.fa
+        if [ ! -s megahit_out/*.fa ]; then
+            echo "No contigs assembled" | tee /dev/stderr
+            exit 1
+        fi
 
-    mv megahit_out/* .
+        export kmax=\$(grep "k-max reset to" megahit_out/*log | rev | cut -f 2 -d ' ' | rev)
+        megahit_toolkit contig2fastg \$kmax megahit_out/*.fa > megahit_out/${prefix}.contigs.fastg
 
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        megahit: \$(echo \$(megahit -v 2>&1) | sed 's/MEGAHIT v//')
-    END_VERSIONS
-    """
+        pigz \\
+            --no-name \\
+            -p $task.cpus \\
+            $args2 \\
+            megahit_out/*.fa \\
+            megahit_out/intermediate_contigs/*.fa \\
+            megahit_out/*.fastg
 
-    stub:
-    def args = task.ext.args ?: ''
-    def args2 = task.ext.args2 ?: ''
-    def prefix = task.ext.prefix ?: "${meta.id}"
-    def reads_command = meta.single_end ? "-r ${reads}" : "-1 ${reads[0]} -2 ${reads[1]}"
-    """
-    mkdir -p intermediate_contigs
-    echo "" | gzip > ${prefix}.contigs.fa.gz
-    echo "" | gzip > intermediate_contigs/k21.contigs.fa.gz
-    echo "" | gzip > intermediate_contigs/k21.addi.fa.gz
-    echo "" | gzip > intermediate_contigs/k21.local.fa.gz
-    echo "" | gzip > intermediate_contigs/k21.final.contigs.fa.gz
-    touch ${prefix}.log
+        cat <<-END_VERSIONS > versions.yml
+        "${task.process}":
+            megahit: \$(echo \$(megahit -v 2>&1) | sed 's/MEGAHIT v//')
+        END_VERSIONS
+        """
+    } else {
+        """
+        megahit \\
+            -1 ${reads[0]} \\
+            -2 ${reads[1]} \\
+            -t $task.cpus \\
+            $args \\
+            --out-prefix $prefix
 
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        megahit: \$(echo \$(megahit -v 2>&1) | sed 's/MEGAHIT v//')
-    END_VERSIONS
-    """
+        if [ ! -s megahit_out/*.fa ]; then
+            echo "No contigs assembled" | tee /dev/stderr
+            exit 1
+        fi
+
+        export kmax=\$(grep "k-max reset to" megahit_out/*log | rev | cut -f 2 -d ' ' | rev)
+        megahit_toolkit contig2fastg \$kmax megahit_out/*.fa > megahit_out/${prefix}.contigs.fastg
+
+        pigz \\
+            --no-name \\
+            -p $task.cpus \\
+            $args2 \\
+            megahit_out/*.fa \\
+            megahit_out/intermediate_contigs/*.fa \\
+            megahit_out/*.fastg
+
+        cat <<-END_VERSIONS > versions.yml
+        "${task.process}":
+            megahit: \$(echo \$(megahit -v 2>&1) | sed 's/MEGAHIT v//')
+        END_VERSIONS
+        """
+    }
 }

--- a/modules/nf-core/megahit/main.nf
+++ b/modules/nf-core/megahit/main.nf
@@ -1,23 +1,23 @@
 process MEGAHIT {
-    tag "$meta.id"
+    tag "${meta.id}"
     label 'process_high'
-
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/mulled-v2-0f92c152b180c7cd39d9b0e6822f8c89ccb59c99:8ec213d21e5d03f9db54898a2baeaf8ec729b447-0' :
-        'biocontainers/mulled-v2-0f92c152b180c7cd39d9b0e6822f8c89ccb59c99:8ec213d21e5d03f9db54898a2baeaf8ec729b447-0' }"
+        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/f2/f2cb827988dca7067ff8096c37cb20bc841c878013da52ad47a50865d54efe83/data' :
+        'community.wave.seqera.io/library/megahit_pigz:87a590163e594224' }"
 
     input:
     tuple val(meta), path(reads)
 
     output:
-    tuple val(meta), path("megahit_out/*.contigs.fa.gz")                            , emit: contigs
-    tuple val(meta), path("megahit_out/*.fastg.gz")                                 , emit: graph
-    tuple val(meta), path("megahit_out/intermediate_contigs/k*.contigs.fa.gz")      , emit: k_contigs
-    tuple val(meta), path("megahit_out/intermediate_contigs/k*.addi.fa.gz")         , emit: addi_contigs
-    tuple val(meta), path("megahit_out/intermediate_contigs/k*.local.fa.gz")        , emit: local_contigs
-    tuple val(meta), path("megahit_out/intermediate_contigs/k*.final.contigs.fa.gz"), emit: kfinal_contigs
-    path "versions.yml"                                                             , emit: versions
+    tuple val(meta), path("*.contigs.fa.gz")                            , emit: contigs
+    tuple val(meta), path("*.fastg.gz")                                 , emit: graph
+    tuple val(meta), path("intermediate_contigs/k*.contigs.fa.gz")      , emit: k_contigs
+    tuple val(meta), path("intermediate_contigs/k*.addi.fa.gz")         , emit: addi_contigs
+    tuple val(meta), path("intermediate_contigs/k*.local.fa.gz")        , emit: local_contigs
+    tuple val(meta), path("intermediate_contigs/k*.final.contigs.fa.gz"), emit: kfinal_contigs
+    tuple val(meta), path('*.log')                                      , emit: log
+    path "versions.yml"                                                 , emit: versions
 
     when:
     task.ext.when == null || task.ext.when
@@ -26,64 +26,51 @@ process MEGAHIT {
     def args = task.ext.args ?: ''
     def args2 = task.ext.args2 ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
-    if (meta.single_end) {
-        """
-        megahit \\
-            -r ${reads} \\
-            -t $task.cpus \\
-            $args \\
-            --out-prefix $prefix
+    def reads_command = meta.single_end ? "-r ${reads}" : "-1 ${reads[0]} -2 ${reads[1]}"
+    """
+    megahit \\
+        ${reads_command} \\
+        ${args} \\
+        -t ${task.cpus} \\
+        --out-prefix ${prefix}
 
-        if [ ! -s megahit_out/*.fa ]; then
-            echo "No contigs assembled" | tee /dev/stderr
-            exit 1
-        fi
+    export kmax=\$(grep "k-max reset to" megahit_out/*log | rev | cut -f 2 -d ' ' | rev)
+    megahit_toolkit contig2fastg \$kmax megahit_out/*.fa > megahit_out/${prefix}.contigs.fastg
 
-        export kmax=\$(grep "k-max reset to" megahit_out/*log | rev | cut -f 2 -d ' ' | rev)
-        megahit_toolkit contig2fastg \$kmax megahit_out/*.fa > megahit_out/${prefix}.contigs.fastg
+    pigz \\
+        --no-name \\
+        -p ${task.cpus} \\
+        ${args2} \\
+        megahit_out/*.fa \\
+        megahit_out/*.fastg \\
+        megahit_out/intermediate_contigs/*.fa
 
-        pigz \\
-            --no-name \\
-            -p $task.cpus \\
-            $args2 \\
-            megahit_out/*.fa \\
-            megahit_out/intermediate_contigs/*.fa \\
-            megahit_out/*.fastg
+    mv megahit_out/* .
 
-        cat <<-END_VERSIONS > versions.yml
-        "${task.process}":
-            megahit: \$(echo \$(megahit -v 2>&1) | sed 's/MEGAHIT v//')
-        END_VERSIONS
-        """
-    } else {
-        """
-        megahit \\
-            -1 ${reads[0]} \\
-            -2 ${reads[1]} \\
-            -t $task.cpus \\
-            $args \\
-            --out-prefix $prefix
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        megahit: \$(echo \$(megahit -v 2>&1) | sed 's/MEGAHIT v//')
+    END_VERSIONS
+    """
 
-        if [ ! -s megahit_out/*.fa ]; then
-            echo "No contigs assembled" | tee /dev/stderr
-            exit 1
-        fi
+    stub:
+    def args = task.ext.args ?: ''
+    def args2 = task.ext.args2 ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    def reads_command = meta.single_end ? "-r ${reads}" : "-1 ${reads[0]} -2 ${reads[1]}"
+    """
+    mkdir -p intermediate_contigs
+    echo "" | gzip > ${prefix}.contigs.fa.gz
+    echo "" | gzip > ${prefix}.contigs.fastg.gz
+    echo "" | gzip > intermediate_contigs/k21.contigs.fa.gz
+    echo "" | gzip > intermediate_contigs/k21.addi.fa.gz
+    echo "" | gzip > intermediate_contigs/k21.local.fa.gz
+    echo "" | gzip > intermediate_contigs/k21.final.contigs.fa.gz
+    touch ${prefix}.log
 
-        export kmax=\$(grep "k-max reset to" megahit_out/*log | rev | cut -f 2 -d ' ' | rev)
-        megahit_toolkit contig2fastg \$kmax megahit_out/*.fa > megahit_out/${prefix}.contigs.fastg
-
-        pigz \\
-            --no-name \\
-            -p $task.cpus \\
-            $args2 \\
-            megahit_out/*.fa \\
-            megahit_out/intermediate_contigs/*.fa \\
-            megahit_out/*.fastg
-
-        cat <<-END_VERSIONS > versions.yml
-        "${task.process}":
-            megahit: \$(echo \$(megahit -v 2>&1) | sed 's/MEGAHIT v//')
-        END_VERSIONS
-        """
-    }
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        megahit: \$(echo \$(megahit -v 2>&1) | sed 's/MEGAHIT v//')
+    END_VERSIONS
+    """
 }

--- a/modules/nf-core/megahit/megahit.diff
+++ b/modules/nf-core/megahit/megahit.diff
@@ -1,9 +1,10 @@
 Changes in module 'nf-core/megahit'
+'modules/nf-core/megahit/meta.yml' is unchanged
 'modules/nf-core/megahit/environment.yml' is unchanged
 Changes in 'megahit/main.nf':
 --- modules/nf-core/megahit/main.nf
 +++ modules/nf-core/megahit/main.nf
-@@ -7,7 +7,7 @@
+@@ -7,10 +7,11 @@
          'community.wave.seqera.io/library/megahit_pigz:87a590163e594224' }"
  
      input:
@@ -12,7 +13,11 @@ Changes in 'megahit/main.nf':
  
      output:
      tuple val(meta), path("*.contigs.fa.gz")                            , emit: contigs
-@@ -25,7 +25,7 @@
++    tuple val(meta), path("*.fastg.gz")                                 , emit: graph
+     tuple val(meta), path("intermediate_contigs/k*.contigs.fa.gz")      , emit: k_contigs
+     tuple val(meta), path("intermediate_contigs/k*.addi.fa.gz")         , emit: addi_contigs
+     tuple val(meta), path("intermediate_contigs/k*.local.fa.gz")        , emit: local_contigs
+@@ -25,7 +26,7 @@
      def args = task.ext.args ?: ''
      def args2 = task.ext.args2 ?: ''
      def prefix = task.ext.prefix ?: "${meta.id}"
@@ -21,7 +26,23 @@ Changes in 'megahit/main.nf':
      """
      megahit \\
          ${reads_command} \\
-@@ -52,7 +52,7 @@
+@@ -33,11 +34,15 @@
+         -t ${task.cpus} \\
+         --out-prefix ${prefix}
+ 
++    export kmax=\$(grep "k-max reset to" megahit_out/*log | rev | cut -f 2 -d ' ' | rev)
++    megahit_toolkit contig2fastg \$kmax megahit_out/*.fa > megahit_out/${prefix}.contigs.fastg
++
+     pigz \\
+         --no-name \\
+         -p ${task.cpus} \\
+         ${args2} \\
+         megahit_out/*.fa \\
++        megahit_out/*.fastg \\
+         megahit_out/intermediate_contigs/*.fa
+ 
+     mv megahit_out/* .
+@@ -52,10 +57,11 @@
      def args = task.ext.args ?: ''
      def args2 = task.ext.args2 ?: ''
      def prefix = task.ext.prefix ?: "${meta.id}"
@@ -30,9 +51,12 @@ Changes in 'megahit/main.nf':
      """
      mkdir -p intermediate_contigs
      echo "" | gzip > ${prefix}.contigs.fa.gz
++    echo "" | gzip > ${prefix}.contigs.fastg.gz
+     echo "" | gzip > intermediate_contigs/k21.contigs.fa.gz
+     echo "" | gzip > intermediate_contigs/k21.addi.fa.gz
+     echo "" | gzip > intermediate_contigs/k21.local.fa.gz
 
-'modules/nf-core/megahit/meta.yml' is unchanged
 'modules/nf-core/megahit/tests/tags.yml' is unchanged
-'modules/nf-core/megahit/tests/main.nf.test.snap' is unchanged
 'modules/nf-core/megahit/tests/main.nf.test' is unchanged
+'modules/nf-core/megahit/tests/main.nf.test.snap' is unchanged
 ************************************************************


### PR DESCRIPTION
Added generation of the fastg graph with megahit_toolkit. 
Kmax has to be extracted from the log file. It is not explicitly declared anywhere (there is a default, but megahit might change it if the read length is shorter than kmax), hence the manual extraction from the log. 