### PR TITLE
Patch the bwamem2 retry policy

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -94,17 +94,21 @@ process {
 
     /* Decontamination */
     withName: 'BWAMEM2DECONTNOBAMS' {
+        // BWAMEM2 is a bit wonky so we will retry regarless of the exit code
+        errorStrategy = 'retry'
+        maxRetries = 2
+
         cpus   = { 2     * task.attempt }
         time   = { 8.h   * task.attempt }
         ext.prefix = "decontaminated"
     }
 
     withName: 'HUMAN_PHIX_DECONTAMINATION' {
-        memory = { 64.GB * task.attempt }
+        memory = { 64.GB + ( 64.GB * 0.5 * ( task.attempt - 1 ) ) }
     }
 
     withName: 'HOST_DECONTAMINATION' {
-        memory = { 24.GB * task.attempt }
+        memory = { 24.GB + ( 24.GB * 0.5 * ( task.attempt - 1 ) ) }
     }
 
     withName: 'CANU*' {


### PR DESCRIPTION
ATM bwamem2 it's not getting retries, that is because the pipefail + samtools maybe forcing an error code 1.

Ths bwamem2 modules should rety now, with 50% more memory each time.

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/ebi-metagenomics/miassembler/tree/master/.github/CONTRIBUTING.md)
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
