### PR TITLE
Remove extra column from blast output

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -252,7 +252,7 @@ process {
             '-window_size',
             '100',
             '-outfmt',
-            '"6 qseqid ppos"',
+            '"6 qseqid"',
         ].join(' ').trim()
 
         publishDir = [


### PR DESCRIPTION
This is the change needed for seqkit to successfully filter out contaminated contigs, the issues is described in [https://www.ebi.ac.uk/panda/jira/browse/EMG-7172] and affects both human and host decontamination post-assembly. This implies that as of now, it's like we are not decontaminating at all post-assembly. 

Jenny is doing a small benchmark of how many of her assemblies are affected by this.
out of ~1200 assemblies, 238 are contaminated by host. She is currently checking how many are contaminated by human.

My understanding is that Sonia already checked, and the blast score isn't used anywhere in our pipelines. If that is NOT the case, this is what the draft PR is for, otherwise we can already implement it in the pipeline.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/ebi-metagenomics/miassembler/tree/master/.github/CONTRIBUTING.md)
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
