### PR TITLE
Feature/double lr quality thresholds

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,8 @@ Reads QC options
 are retained after filtering, the threshold is considered exceeded, and the run is not assembled. [default: 0.1]
   --short_reads_low_reads_count_threshold [number]  The minimum number of reads required after filtering. If below, it flags a low read count and the run is not assembled. [default: 1000]
   --long_reads_min_read_length            [integer] Minimum read length for pre-assembly quality filtering [default: 200]
-  --long_reads_pacbio_quality_threshold   [number]  The Q20 threshold that a pacbio sample needs to exceed to be labelled as HiFi. [default: 0.8]
+  --long_reads_pacbio_quality_threshold   [number]  The Q20 threshold that a pacbio sample needs to exceed to be labelled as HiFi. [default: 0.9]
+  --long_reads_ont_quality_threshold      [number]  The Q20 threshold that an ONT sample needs to exceed to be labelled as high-quality. [default: 0.8]
 
 Assembly QC options
   --short_reads_min_contig_length         [integer] Minimum contig length filter for short reads. [default: 500]

--- a/conf/test.config
+++ b/conf/test.config
@@ -29,8 +29,6 @@ profiles {
             diamond_db                       = "${projectDir}/tests/diamond_db/mini_db.dmnd"
             human_fasta_prefix               = "human"
 
-            // TODO: change feature/LR to dev/main in test_long_reads_HQ.csv after merge to dev/main
-
             max_spades_retries               = -1
             max_megahit_retries              = -1
         }

--- a/nextflow.config
+++ b/nextflow.config
@@ -32,7 +32,8 @@ params {
     short_reads_low_reads_count_threshold = 1000
 
     // Long reads options
-    long_reads_pacbio_quality_threshold = 0.8
+    long_reads_pacbio_quality_threshold = 0.9
+    long_reads_ont_quality_threshold    = 0.8
     long_reads_min_read_length          = 200
 
     // Short reads reference databases (name to be selected from list)

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -219,6 +219,13 @@
                 "long_reads_pacbio_quality_threshold": {
                     "type": "number",
                     "description": "The Q20 threshold that a pacbio sample needs to exceed to be labelled as HiFi.",
+                    "default": 0.9,
+                    "minimum": 0.0,
+                    "maximum": 1.0
+                },
+                "long_reads_ont_quality_threshold": {
+                    "type": "number",
+                    "description": "The Q20 threshold that an ONT sample needs to exceed to be labelled as high-quality.",
                     "default": 0.8,
                     "minimum": 0.0,
                     "maximum": 1.0

--- a/subworkflows/local/long_reads_qc.nf
+++ b/subworkflows/local/long_reads_qc.nf
@@ -31,10 +31,18 @@ workflow LONG_READS_QC {
         
         def q20_percentage = json_txt?.summary?.before_filtering?.q20_rate ?: 0;
 
-        if ( q20_percentage >= params.long_reads_pacbio_quality_threshold ) {
-            return [ meta + [quality: "high"], reads]
-        } else {
-            return [ meta + [quality: "low"], reads]
+        if (meta.platform == "ont"){
+            if ( q20_percentage >= params.long_reads_ont_quality_threshold ) {
+                return [ meta + [quality: "high"], reads]
+            } else {
+                return [ meta + [quality: "low"], reads]
+            }
+        } else if (meta.platform == "pb") {
+            if ( q20_percentage >= params.long_reads_pacbio_quality_threshold ) {
+                return [ meta + [quality: "high"], reads]
+            } else {
+                return [ meta + [quality: "low"], reads]
+            }
         }
     }
 

--- a/tests/samplesheet/test_long_reads_HQ.csv
+++ b/tests/samplesheet/test_long_reads_HQ.csv
@@ -1,3 +1,3 @@
 study_accession,reads_accession,fastq_1,fastq_2,library_layout,library_strategy,platform,assembler,assembly_memory,assembler_config
 SRP040735,SRR1211893,https://github.com/EBI-Metagenomics/miassembler/raw/main/tests/test_reads/SRR1211893.fastq.gz,,single,metagenomic,ont,,,nano-hq
-SRP040735,SRR1211893,https://github.com/EBI-Metagenomics/miassembler/raw/main/tests/test_reads/SRR1211893.fastq.gz,,single,metagenomic,pb,,,
+SRP040735,SRR1211893,https://github.com/EBI-Metagenomics/miassembler/raw/main/tests/test_reads/SRR1211893.fastq.gz,,single,metagenomic,pb,,,pacbio-hifi

--- a/tests/samplesheet/test_long_reads_HQ.csv
+++ b/tests/samplesheet/test_long_reads_HQ.csv
@@ -1,3 +1,3 @@
 study_accession,reads_accession,fastq_1,fastq_2,library_layout,library_strategy,platform,assembler,assembly_memory,assembler_config
-SRP040735,SRR1211893,https://github.com/EBI-Metagenomics/miassembler/raw/feature/long_read_assembly/tests/test_reads/SRR1211893.fastq.gz,,single,metagenomic,ont,,,nano-hq
-SRP040735,SRR1211893,https://github.com/EBI-Metagenomics/miassembler/raw/feature/long_read_assembly/tests/test_reads/SRR1211893.fastq.gz,,single,metagenomic,pb,,,pacbio-hifi
+SRP040735,SRR1211893,https://github.com/EBI-Metagenomics/miassembler/raw/main/tests/test_reads/SRR1211893.fastq.gz,,single,metagenomic,ont,,,nano-hq
+SRP040735,SRR1211893,https://github.com/EBI-Metagenomics/miassembler/raw/main/tests/test_reads/SRR1211893.fastq.gz,,single,metagenomic,pb,,,


### PR DESCRIPTION
There used to be a unique quality threshold for long read data. In this PR, I added a quality threshold so that pacbio and ont can be handled separately.