### PR TITLE
adds additional retry (with more ram) for bwa-mem2 index

### DIFF
--- a/modules/local/short_reads_coverage/main.nf
+++ b/modules/local/short_reads_coverage/main.nf
@@ -1,6 +1,6 @@
 process SHORT_READS_INDEX_FASTA {
 
-    label 'process_medium'
+    label ['process_medium', 'error_retry']
     tag "${meta.id}"
 
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?


### PR DESCRIPTION
Bwa-mem2 indexing can fail even on second attempt (36GB * 2 RAM in current default config). This PR just adds an additional retry (max 3 attempts, i.e. 108GB RAM on final attempt).

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/ebi-metagenomics/miassembler/tree/master/.github/CONTRIBUTING.md)
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
