### PR TITLE
Added a skip_human_decontamination flag - not to be used much.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Input/output options
   --private_study                         [boolean] To use if the ENA study is private, *this feature ony works on EBI infrastructure at the moment*
   --reference_genomes_folder              [string]  The folder with the reference genomes.
   --contaminant_reference                 [string]  Filename of the reference genome located in <reference_genomes_folder> to be used for host decontamination
+  --skip_human_decontamination            [boolean] Scrubbing human contamination from raw reads and assembled contigs is performed by default as standard procedure. Set this flag to true to skip human decontamination. [default: false]
   --human_reference                       [string]  Filename of the human genome reference located in <reference_genomes_folder> to be used for human decontamination
   --phix_reference                        [string]  Filename of the PhiX genome reference located in <reference_genomes_folder> to be used for decontamination of Illumina reads
   --diamond_db                            [string]  Path to diamond db (e.g. NCBI-nr) to perform frameshift correction [default: ]

--- a/assets/human_decontamination_mqc.html
+++ b/assets/human_decontamination_mqc.html
@@ -1,0 +1,3 @@
+<div class="alert alert-warning" role="alert">
+  Human data decontamination has been <b>disabled</b> for this pipeline execution.
+</div>

--- a/conf/test.config
+++ b/conf/test.config
@@ -24,6 +24,8 @@ profiles {
             outdir                           = "${projectDir}/tests/results"
 
             reference_genomes_folder         = "${projectDir}/tests/references"
+            // for testing purposes we use a phix genome as human reference
+            human_reference                  = "phix.fasta"
             diamond_db                       = "${projectDir}/tests/diamond_db/mini_db.dmnd"
 
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -35,6 +35,9 @@ params {
     long_reads_pacbio_quality_threshold = 0.8
     long_reads_min_read_length          = 200
 
+    // CAUTION: setting this variable to false will skip the human decontamination of human data from the raw reads and assembled contigs.
+    skip_human_decontamination = false
+
     // Reference genomes for decontamination of reads and contigs (both long- and short-read data)
     // In contrast to the corresponding samplesheet parameters, these parameters are applied to all samples
     reference_genomes_folder = null

--- a/nextflow.config
+++ b/nextflow.config
@@ -35,7 +35,7 @@ params {
     long_reads_pacbio_quality_threshold = 0.8
     long_reads_min_read_length          = 200
 
-    // CAUTION: setting this variable to false will skip the human decontamination of human data from the raw reads and assembled contigs.
+    // CAUTION: setting this variable to false skips human decontamination of raw reads and assembled contigs.
     skip_human_decontamination = false
 
     // Reference genomes for decontamination of reads and contigs (both long- and short-read data)

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -47,6 +47,12 @@
                     "type": "string",
                     "description": "Filename of the reference genome located in <reference_genomes_folder> to be used for host decontamination"
                 },
+                "skip_human_decontamination": {
+                    "type": "boolean",
+                    "description": "Scrubbing human contamination from raw reads and assembled contigs is performed by default as standard procedure. Set this flag to true to skip human decontamination.",
+                    "help_text": "CAUTION: Setting this variable to true will skip the removal of human sequences from raw reads and assembled contigs.",
+                    "default": false
+                },
                 "human_reference": {
                     "type": "string",
                     "description": "Filename of the human genome reference located in <reference_genomes_folder> to be used for human decontamination"

--- a/subworkflows/local/long_reads_assembly_qc.nf
+++ b/subworkflows/local/long_reads_assembly_qc.nf
@@ -21,7 +21,7 @@ workflow LONG_READS_ASSEMBLY_QC {
 
     human_subdivided_assemblies.run_decontamination
         .map { meta, contigs ->
-            [ [meta, contigs], "${params.reference_genomes_folder}/${meta.human_reference}" ]
+            [ [meta, contigs], file("${params.reference_genomes_folder}/${meta.human_reference}", checkIfExists: true) ]
         }
         .set { ch_human_decontamination_input }
 
@@ -45,7 +45,7 @@ workflow LONG_READS_ASSEMBLY_QC {
 
     subdivided_assemblies.run_decontamination
         .map { meta, contigs ->
-            [ [meta, contigs], "${params.reference_genomes_folder}/${meta.contaminant_reference}" ]
+            [ [meta, contigs], file("${params.reference_genomes_folder}/${meta.contaminant_reference}", checkIfExists: true) ]
         }
         .set { ch_decontamination_input }
 

--- a/subworkflows/local/long_reads_qc.nf
+++ b/subworkflows/local/long_reads_qc.nf
@@ -48,9 +48,9 @@ workflow LONG_READS_QC {
         .set { human_subdivided_reads }
 
     human_subdivided_reads.run_decontamination
-        .multiMap { meta, reads ->
-            reads: [meta, reads]
-            reference: [ [id:"human"], "${params.reference_genomes_folder}/${meta.human_reference}" ]
+        .multiMap { meta, reads_ ->
+            reads: [meta, reads_]
+            reference: [ [id:"human"], file("${params.reference_genomes_folder}/${meta.human_reference}", checkIfExists: true)]
         }
         .set { ch_human_decontamination_input }
 
@@ -84,9 +84,9 @@ workflow LONG_READS_QC {
         .set { subdivided_reads }
 
     subdivided_reads.run_decontamination
-        .multiMap { meta, reads ->
-            reads: [meta, reads]
-            reference: [ [id:file(meta.contaminant_reference).baseName], "${params.reference_genomes_folder}/${meta.contaminant_reference}" ]
+        .multiMap { meta, reads_ ->
+            reads: [meta, reads_]
+            reference: [ [id:file(meta.contaminant_reference).baseName], file("${params.reference_genomes_folder}/${meta.contaminant_reference}", checkIfExists: true) ]
         }
         .set { ch_decontamination_input }
 

--- a/subworkflows/local/short_reads_assembly_qc.nf
+++ b/subworkflows/local/short_reads_assembly_qc.nf
@@ -65,7 +65,7 @@ workflow SHORT_READS_ASSEMBLY_QC {
 
     human_subdivided_assemblies.run_decontamination
         .map { meta, contigs ->
-            [ [meta, contigs], "${params.reference_genomes_folder}/${meta.human_reference}" ]
+            [ [meta, contigs], file( "${params.reference_genomes_folder}/${meta.human_reference}", checkIfExists: true ) ]
         }
         .set { ch_human_decontamination_input }
 

--- a/subworkflows/local/short_reads_qc.nf
+++ b/subworkflows/local/short_reads_qc.nf
@@ -33,9 +33,9 @@ workflow SHORT_READS_QC {
         .set { human_subdivided_reads }
 
     human_subdivided_reads.run_decontamination
-        .multiMap { meta, reads ->
-            reads: [meta, reads]
-            reference: [ [id:"human"], file("${params.reference_genomes_folder}/${meta.human_reference}.*") ]
+        .multiMap { meta, reads_ ->
+            reads: [meta, reads_]
+            reference: [ [id:"human"], file("${params.reference_genomes_folder}/${meta.human_reference}.*", checkIfExists: true) ]
         }
         .set { ch_human_decontamination_input }
 
@@ -89,8 +89,8 @@ workflow SHORT_READS_QC {
         .set { subdivided_reads }
 
     subdivided_reads.run_decontamination
-        .multiMap { meta, reads ->
-            reads: [meta, reads]
+        .multiMap { meta, reads_ ->
+            reads: [meta, reads_]
             reference: [ [id:file(meta.contaminant_reference).baseName], file("${params.reference_genomes_folder}/${meta.contaminant_reference}.*") ]
         }
         .set { ch_decontamination_input }

--- a/tests/main.nf.test
+++ b/tests/main.nf.test
@@ -427,7 +427,7 @@ nextflow_pipeline {
                 samplesheet                 = "${projectDir}/tests/samplesheet/test.csv"
                 // This is incompatible - we want the human decontamination to be avoided if possible
                 skip_human_decontamination  = true
-                human_reference              = "human.fasta"
+                human_reference             = "human.fasta"
             }
         }
 

--- a/tests/main.nf.test
+++ b/tests/main.nf.test
@@ -427,7 +427,7 @@ nextflow_pipeline {
                 samplesheet                 = "${projectDir}/tests/samplesheet/test.csv"
                 // This is incompatible - we want the human decontamination to be avoided if possible
                 skip_human_decontamination  = true
-                human_reference             = "human.fasta"
+                human_reference             = "human.fna"
             }
         }
 

--- a/tests/main.nf.test
+++ b/tests/main.nf.test
@@ -396,6 +396,7 @@ nextflow_pipeline {
                 samplesheet                 = "${projectDir}/tests/samplesheet/test.csv"
                 skip_human_decontamination  = true
 
+                human_reference             = null
                 phix_reference              = "phix.fasta"
             }
         }

--- a/tests/main.nf.test
+++ b/tests/main.nf.test
@@ -25,7 +25,7 @@ nextflow_pipeline {
 
     }
 
-    test("Samplesheet - no assembled - reads filtered ") {
+    test("Samplesheet - no assembled - reads filtered") {
 
         tag "samplesheet"
         tag "SR"
@@ -327,9 +327,9 @@ nextflow_pipeline {
                 assert trace.succeeded().count{ task -> task.name.contains("LONG_READS_QC:MINIMAP2_ALIGN_HUMAN") } == 2
                 assert trace.succeeded().count{ task -> task.name.contains("FASTQC_AFTER") } == 2
                 assert trace.succeeded().count{ task -> task.name.contains("PACBIO_HIFI:HIFIADAPTERFILT") } == 1
-                
+
                 assert trace.failed().count{ task -> task.name.contains("PACBIO_HIFI:FLYE") } == 1
-                
+
                 assert trace.succeeded().count{ task -> task.name.contains("ONT_HQ:PORECHOP_ABI") } == 1
                 assert trace.succeeded().count{ task -> task.name.contains("ONT_HQ:FLYE") } == 1
                 assert trace.succeeded().count{ task -> task.name.contains("LONG_READS_ASSEMBLY_QC:HUMAN_DECONTAMINATE_CONTIGS") } == 3
@@ -380,6 +380,60 @@ nextflow_pipeline {
 
 
                 assert trace.tasks().size() == 15
+            }
+        }
+    }
+
+    test("Skip human decontamination - warning displayed and processes skipped") {
+
+        tag "samplesheet"
+        tag "skip_human_decontamination"
+        tag "SR"
+
+        when {
+            params {
+                assembler                   = "spades"
+                samplesheet                 = "${projectDir}/tests/samplesheet/test.csv"
+                skip_human_decontamination  = true
+
+                phix_reference              = "phix.fasta"
+            }
+        }
+
+        then {
+            with(workflow) {
+                assert success
+
+                // Verify human decontamination processes are not executed
+                assert trace.succeeded().count{ task -> task.name.contains("MINIMAP2_ALIGN_HUMAN") } == 0
+                assert trace.succeeded().count{ task -> task.name.contains("HUMAN_DECONTAMINATE_CONTIGS") } == 0
+                assert trace.succeeded().count{ task -> task.name.contains("SPADES") } == 2
+                assert trace.succeeded().count{ task -> task.name.contains("PHIX_READS_DECONTAMINATION") } == 3
+                assert trace.succeeded().count{ task -> task.name.contains("FASTQC_BEFORE") } == 3
+                assert trace.succeeded().count{ task -> task.name.contains("MULTIQC_STUDY") } == 2
+            }
+        }
+    }
+
+    test("Skip human decontamination - throw an error if the human_reference is provided and skip human decont is true") {
+
+        tag "samplesheet"
+        tag "skip_human_decontamination"
+        tag "SR"
+
+        when {
+            params {
+                assembler                   = "spades"
+                samplesheet                 = "${projectDir}/tests/samplesheet/test.csv"
+                // This is incompatible - we want the human decontamination to be avoided if possible
+                skip_human_decontamination  = true
+                human_reference              = "human.fasta"
+            }
+        }
+
+        then {
+            with(workflow) {
+                assert !success
             }
         }
     }

--- a/workflows/miassembler.nf
+++ b/workflows/miassembler.nf
@@ -99,6 +99,12 @@ workflow MIASSEMBLER {
 
     if (params.samplesheet) {
         def groupReads = { study_accession, reads_accession, fq1, fq2, library_layout, library_strategy, platform, assembler, assembly_memory, assembler_config, contaminant_reference, human_reference, phix_reference ->
+
+            def human_reference_path = human_reference ?: params.human_reference
+            if (!params.skip_human_decontamination && human_reference_path == null) {
+                error "Invalid row, skip_human_decontamination is false but there is no human reference on row: ${study_accession}, ${reads_accession}."
+            }
+
             if (fq2 == []) {
                 return tuple(
                     [
@@ -112,7 +118,7 @@ workflow MIASSEMBLER {
                         "assembly_memory": assembly_memory ?: params.assembly_memory,
                         "assembler_config": assembler_config ?: params.long_reads_assembler_config,
                         "contaminant_reference": contaminant_reference ?: params.contaminant_reference,
-                        "human_reference": params.skip_human_decontamination ? null : (human_reference ?: params.human_reference),
+                        "human_reference": human_reference_path, // -> if this value is null (which is not the same as an empty string) the decontamination won't be executed
                         "phix_reference": phix_reference ?: params.phix_reference
                     ],
                     [fq1]


### PR DESCRIPTION
I feel this is overcomplicating things.. but having the flexibility to disable the human decontamination could be useful (🤞).

Anyway.. here we are.

I've added a skip_human_decontamination flag now... which is off by default. If used then a warning will be printed in the log and a bit of markdown inserted into the multiqc report.

@ochkalova I've added a bunch of `checkIfExists` things to check for the references to exist. It's sort of repeated, as those are in loops... but it should be fine as it should be very cheap for nextflow to check if a file exists on not.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [x] `README.md` is updated (including new tool citations and authors/contributors).
