### PR TITLE
adds additional retry (with more ram) for bwa-mem2 host decontamination

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -98,7 +98,7 @@ process {
             if ( ( Math.ceil( index.size() / (1024**3)) ).GB >= 5.GB ) {
                 base_memory = 64.GB
             }
-            base_memory + ( base_memory * 0.5 * ( task.attempt - 1 ) )
+            return base_memory + ( base_memory * 0.5 * ( task.attempt - 1 ) )
         }
     }
 

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -91,15 +91,19 @@ process {
         memory = { 64.GB + ( 64.GB * 0.5 * ( task.attempt - 1 ) ) }
     }
 
-    withName: '(PHIX|HOST)_READS_DECONTAMINATION' {
+    withName: 'HOST_READS_DECONTAMINATION' {
         memory = {
             // This needs to be adjusted, as tthis is inteded to manage memory when the index is massive (e.g., wheat).
             def base_memory = 24.GB
             if ( ( Math.ceil( index.size() / (1024**3)) ).GB >= 5.GB ) {
-                base_memory = 64.GB
+                base_memory = 84.GB
             }
             return base_memory + ( base_memory * 0.5 * ( task.attempt - 1 ) )
         }
+    }
+
+    withName: 'PHIX_READS_DECONTAMINATION' {
+        memory = { 6.GB + ( 6.GB * 0.5 * ( task.attempt - 1 ) ) }
     }
 
     withName: '.*:LONG_READS_QC:MINIMAP2_ALIGN_.*' {

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -82,7 +82,7 @@ process {
         errorStrategy = 'retry'
         maxRetries = 2
 
-        cpus   = { 2     * task.attempt }
+        cpus   = { 16                   }
         time   = { 8.h   * task.attempt }
         ext.prefix = "decontaminated"
     }
@@ -92,7 +92,13 @@ process {
     }
 
     withName: '(PHIX|HOST)_READS_DECONTAMINATION' {
-        memory = { 24.GB + ( 24.GB * 0.5 * ( task.attempt - 1 ) ) }
+        memory = {
+            def base_memory = 24.GB
+            if ( ( Math.ceil( index.size() / (1024**3)) ).GB >= 5.GB ) {
+                base_memory = 64.GB
+            }
+            base_memory + ( base_memory * 0.5 * ( task.attempt - 1 ) )
+        }
     }
 
     withName: '.*:LONG_READS_QC:MINIMAP2_ALIGN_.*' {

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -93,6 +93,7 @@ process {
 
     withName: '(PHIX|HOST)_READS_DECONTAMINATION' {
         memory = {
+            // This needs to be adjusted, as tthis is inteded to manage memory when the index is massive (e.g., wheat).
             def base_memory = 24.GB
             if ( ( Math.ceil( index.size() / (1024**3)) ).GB >= 5.GB ) {
                 base_memory = 64.GB

--- a/modules/ebi-metagenomics/bwamem2decontnobams/main.nf
+++ b/modules/ebi-metagenomics/bwamem2decontnobams/main.nf
@@ -1,6 +1,7 @@
 process BWAMEM2DECONTNOBAMS {
     tag "$meta.id"
     label 'process_high'
+    label 'error_retry'
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?

--- a/modules/ebi-metagenomics/bwamem2decontnobams/main.nf
+++ b/modules/ebi-metagenomics/bwamem2decontnobams/main.nf
@@ -1,7 +1,6 @@
 process BWAMEM2DECONTNOBAMS {
     tag "$meta.id"
     label 'process_high'
-    label 'error_retry'
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?


### PR DESCRIPTION
Bwa-mem-2 is failing for my wheat samples as the wheat reference is very big. This copies Sandy's PR (https://github.com/EBI-Metagenomics/miassembler/pull/45) to give bwa-mem-2 an additional retry.

<!--
# ebi-metagenomics/miassembler pull request

Many thanks for contributing to ebi-metagenomics/miassembler!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/ebi-metagenomics/miassembler/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [X] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/ebi-metagenomics/miassembler/tree/master/.github/CONTRIBUTING.md)
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
