### PR TITLE
Upgrade bwa-mem2 to version 2.3

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -2,7 +2,7 @@
     "name": "ebi-metagenomics/miassembler",
     "homePage": "https://github.com/ebi-metagenomics/miassembler",
     "repos": {
-        "https://github.com/EBI-Metagenomics/nf-modules": {
+        "https://github.com/ebi-metagenomics/nf-modules": {
             "modules": {
                 "ebi-metagenomics": {
                     "bwamem2/mem": {
@@ -14,7 +14,8 @@
                     "bwamem2decontnobams": {
                         "branch": "main",
                         "git_sha": "32049180387cf2406254acf57882fc55915cb52e",
-                        "installed_by": ["modules"]
+                        "installed_by": ["modules"],
+                        "patch": "modules/ebi-metagenomics/bwamem2decontnobams/bwamem2decontnobams.diff"
                     },
                     "downloadfromfire": {
                         "branch": "main",
@@ -35,7 +36,8 @@
                     "bwamem2/index": {
                         "branch": "master",
                         "git_sha": "3f5420aa22e00bd030a2556dfdffc9e164ec0ec5",
-                        "installed_by": ["modules"]
+                        "installed_by": ["modules"],
+                        "patch": "modules/nf-core/bwamem2/index/bwamem2-index.diff"
                     },
                     "chopper": {
                         "branch": "master",

--- a/modules/ebi-metagenomics/bwamem2/mem/bwamem2-mem.diff
+++ b/modules/ebi-metagenomics/bwamem2/mem/bwamem2-mem.diff
@@ -1,10 +1,17 @@
-Changes in module 'ebi-metagenomics/bwamem2/mem'
+Changes in component 'ebi-metagenomics/bwamem2/mem'
 'modules/ebi-metagenomics/bwamem2/mem/environment.yml' is unchanged
+'modules/ebi-metagenomics/bwamem2/mem/meta.yml' is unchanged
 Changes in 'bwamem2/mem/main.nf':
 --- modules/ebi-metagenomics/bwamem2/mem/main.nf
 +++ modules/ebi-metagenomics/bwamem2/mem/main.nf
-@@ -7,8 +7,7 @@
-         'biocontainers/mulled-v2-e5d375990341c5aef3c9aff74f96f66f65375ef6:2d15960ccea84e249a150b7f5d4db3a42fc2d6c3-0' }"
+@@ -3,12 +3,11 @@
+ 
+     conda "${moduleDir}/environment.yml"
+     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+-        'https://depot.galaxyproject.org/singularity/mulled-v2-e5d375990341c5aef3c9aff74f96f66f65375ef6:2d15960ccea84e249a150b7f5d4db3a42fc2d6c3-0' :
+-        'biocontainers/mulled-v2-e5d375990341c5aef3c9aff74f96f66f65375ef6:2d15960ccea84e249a150b7f5d4db3a42fc2d6c3-0' }"
++        'oras://community.wave.seqera.io/library/bwa-mem2_samtools:0d13d0f418bae5da' :
++        'community.wave.seqera.io/library/bwa-mem2_samtools:df7fb96cc09814fa' }"
  
      input:
 -    tuple val(meta), path(reads)
@@ -22,8 +29,7 @@ Changes in 'bwamem2/mem/main.nf':
      INDEX=`find -L ./ -name "*.amb" | sed 's/\\.amb\$//'`
  
 
-'modules/ebi-metagenomics/bwamem2/mem/meta.yml' is unchanged
-'modules/ebi-metagenomics/bwamem2/mem/tests/tags.yml' is unchanged
 'modules/ebi-metagenomics/bwamem2/mem/tests/main.nf.test.snap' is unchanged
+'modules/ebi-metagenomics/bwamem2/mem/tests/tags.yml' is unchanged
 'modules/ebi-metagenomics/bwamem2/mem/tests/main.nf.test' is unchanged
 ************************************************************

--- a/modules/ebi-metagenomics/bwamem2/mem/main.nf
+++ b/modules/ebi-metagenomics/bwamem2/mem/main.nf
@@ -3,8 +3,8 @@ process BWAMEM2_MEM {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/mulled-v2-e5d375990341c5aef3c9aff74f96f66f65375ef6:2d15960ccea84e249a150b7f5d4db3a42fc2d6c3-0' :
-        'biocontainers/mulled-v2-e5d375990341c5aef3c9aff74f96f66f65375ef6:2d15960ccea84e249a150b7f5d4db3a42fc2d6c3-0' }"
+        'oras://community.wave.seqera.io/library/bwa-mem2_samtools:0d13d0f418bae5da' :
+        'community.wave.seqera.io/library/bwa-mem2_samtools:df7fb96cc09814fa' }"
 
     input:
     tuple val(meta), path(reads), path(index)

--- a/modules/ebi-metagenomics/bwamem2decontnobams/bwamem2decontnobams.diff
+++ b/modules/ebi-metagenomics/bwamem2decontnobams/bwamem2decontnobams.diff
@@ -1,0 +1,22 @@
+Changes in component 'ebi-metagenomics/bwamem2decontnobams'
+'modules/ebi-metagenomics/bwamem2decontnobams/environment.yml' is unchanged
+'modules/ebi-metagenomics/bwamem2decontnobams/meta.yml' is unchanged
+Changes in 'bwamem2decontnobams/main.nf':
+--- modules/ebi-metagenomics/bwamem2decontnobams/main.nf
++++ modules/ebi-metagenomics/bwamem2decontnobams/main.nf
+@@ -4,9 +4,8 @@
+ 
+     conda "${moduleDir}/environment.yml"
+     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+-        'https://depot.galaxyproject.org/singularity/mulled-v2-e5d375990341c5aef3c9aff74f96f66f65375ef6:2d15960ccea84e249a150b7f5d4db3a42fc2d6c3-0' :
+-        'biocontainers/mulled-v2-e5d375990341c5aef3c9aff74f96f66f65375ef6:2d15960ccea84e249a150b7f5d4db3a42fc2d6c3-0' }"
+-
++        'oras://community.wave.seqera.io/library/bwa-mem2_samtools:0d13d0f418bae5da' :
++        'community.wave.seqera.io/library/bwa-mem2_samtools:df7fb96cc09814fa' }"
+ 
+     input:
+     tuple val(meta), path(reads)
+
+'modules/ebi-metagenomics/bwamem2decontnobams/tests/tags.yml' is unchanged
+'modules/ebi-metagenomics/bwamem2decontnobams/tests/main.nf.test' is unchanged
+************************************************************

--- a/modules/ebi-metagenomics/bwamem2decontnobams/main.nf
+++ b/modules/ebi-metagenomics/bwamem2decontnobams/main.nf
@@ -4,9 +4,8 @@ process BWAMEM2DECONTNOBAMS {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/mulled-v2-e5d375990341c5aef3c9aff74f96f66f65375ef6:2d15960ccea84e249a150b7f5d4db3a42fc2d6c3-0' :
-        'biocontainers/mulled-v2-e5d375990341c5aef3c9aff74f96f66f65375ef6:2d15960ccea84e249a150b7f5d4db3a42fc2d6c3-0' }"
-
+        'oras://community.wave.seqera.io/library/bwa-mem2_samtools:0d13d0f418bae5da' :
+        'community.wave.seqera.io/library/bwa-mem2_samtools:df7fb96cc09814fa' }"
 
     input:
     tuple val(meta), path(reads)

--- a/modules/local/short_reads_coverage/main.nf
+++ b/modules/local/short_reads_coverage/main.nf
@@ -5,8 +5,8 @@ process SHORT_READS_INDEX_FASTA {
     tag "${meta.id}"
 
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/8b/8b4b8bec7b2111885ca511c09bbf753e5229ce78f93f9c281819a527c37854af/data':
-        'community.wave.seqera.io/library/bwa-mem2:2.2.1--1842774b9b0b4729' }"
+        'https://depot.galaxyproject.org/singularity/bwa-mem2:2.3--he70b90d_0' :
+        'biocontainers/bwa-mem2:2.3--he70b90d_0' }"
 
     input:
     tuple val(meta), path(fasta)
@@ -38,7 +38,7 @@ process SHORT_READS_COVERAGE {
 
     tag "${meta.id}"
 
-    container 'quay.io/microbiome-informatics/bwa_metabat_concoct:2.2.1_2.16_1.1.0'
+    container 'microbiome-informatics/bwa_metabat_concoct:2.3_2.16_1.1.0'
 
     input:
     tuple val(meta), path(reads), path(ref_fasta), path(ref_fasta_index)

--- a/modules/nf-core/bwamem2/index/bwamem2-index.diff
+++ b/modules/nf-core/bwamem2/index/bwamem2-index.diff
@@ -1,0 +1,19 @@
+Changes in component 'nf-core/bwamem2/index'
+'modules/nf-core/bwamem2/index/environment.yml' is unchanged
+'modules/nf-core/bwamem2/index/meta.yml' is unchanged
+Changes in 'bwamem2/index/main.nf':
+--- modules/nf-core/bwamem2/index/main.nf
++++ modules/nf-core/bwamem2/index/main.nf
+@@ -4,8 +4,8 @@
+ 
+     conda "${moduleDir}/environment.yml"
+     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+-        'https://depot.galaxyproject.org/singularity/bwa-mem2:2.2.1--he513fc3_0' :
+-        'biocontainers/bwa-mem2:2.2.1--he513fc3_0' }"
++        'https://depot.galaxyproject.org/singularity/bwa-mem2:2.3--he70b90d_0' :
++        'biocontainers/bwa-mem2:2.3--he70b90d_0' }"
+ 
+     input:
+     tuple val(meta), path(fasta)
+
+************************************************************

--- a/modules/nf-core/bwamem2/index/main.nf
+++ b/modules/nf-core/bwamem2/index/main.nf
@@ -4,8 +4,8 @@ process BWAMEM2_INDEX {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/bwa-mem2:2.2.1--he513fc3_0' :
-        'biocontainers/bwa-mem2:2.2.1--he513fc3_0' }"
+        'https://depot.galaxyproject.org/singularity/bwa-mem2:2.3--he70b90d_0' :
+        'biocontainers/bwa-mem2:2.3--he70b90d_0' }"
 
     input:
     tuple val(meta), path(fasta)

--- a/nextflow.config
+++ b/nextflow.config
@@ -291,7 +291,7 @@ manifest {
     description     = """Microbiome Informatics metagenomes assembly pipeline"""
     mainScript      = 'main.nf'
     nextflowVersion = '!>=24.04.0'
-    version         = '3.1.13'
+    version         = '3.1.14'
     doi             = ''
 }
 


### PR DESCRIPTION
2.3 is needed to run the pipeline in codon because of the CPUs where upgraded and < 2.3 was compiled a long time ago and do not support those new CPUs.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/ebi-metagenomics/miassembler/tree/master/.github/CONTRIBUTING.md)
- [x] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
